### PR TITLE
Restore access to private gems in gemfile, without GH credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,3 @@
 .env
 
 .sass-cache
-
-# Ignoring Gemfile.lock due to private artsy oauth tokens for github
-# which are used to pull in private, admin gems into the bundle
-Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -32,17 +32,17 @@ end
 
 gem 'foreman'
 gem 'omniauth-oauth2'
-artsy_internal_repo_url 'omniauth-artsy'
-artsy_internal_repo_url 'kinetic'
-# gem 'oauth2', { git: 'https://github.com/matthewrudy/oauth2.git', branch: 'rack2' }
+gem 'oauth2', { git: 'https://github.com/matthewrudy/oauth2.git', branch: 'rack2' }
+gem 'omniauth-artsy', git: 'https://github.com/artsy/omniauth-artsy.git'
+gem 'kinetic', { git: 'https://github.com/artsy/kinetic.git' }
 gem 'typhoeus', '0.7.1'
 gem 'ethon', git: 'https://github.com/dylanfareed/ethon.git'
 gem 'active_attr'
 gem 'haml-rails'
 
-artsy_internal_repo_url 'watt'
+watt_gem_spec = { git: 'https://github.com/artsy/watt.git', branch: 'master' }
 # watt_gem_spec = { path: '../watt' }
-# gem 'watt', watt_gem_spec
+gem 'watt', watt_gem_spec
 gem 'bootstrap-sass'
 gem 'bourbon'
 gem 'neat'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,402 @@
+GIT
+  remote: https://github.com/artsy/kinetic.git
+  revision: 4597fc3de11bfeb511d439ec8f623909b8b66291
+  specs:
+    kinetic (0.0.36)
+      active_attr
+      chronic
+      ethon
+      json
+      omniauth-artsy
+      omniauth-oauth2
+      responders
+      ruby-enum
+      simple_form
+      typhoeus
+
+GIT
+  remote: https://github.com/artsy/omniauth-artsy.git
+  revision: c9beaaac77d6ca6828f8eb4c026d46b3cc5ff58c
+  specs:
+    omniauth-artsy (0.2.0)
+      omniauth-oauth2 (>= 1.0.2)
+
+GIT
+  remote: https://github.com/artsy/watt.git
+  revision: 747ac8cef4499b72a84b6fcdf8d7aabce316368c
+  branch: master
+  specs:
+    watt (0.0.9)
+
+GIT
+  remote: https://github.com/dylanfareed/ethon.git
+  revision: 89ce9784775a7327df3f2208ef4643b5de1ff86f
+  specs:
+    ethon (0.7.3)
+      ffi (>= 1.3.0)
+
+GIT
+  remote: https://github.com/matthewrudy/oauth2.git
+  revision: 030cf008d6821d475f7de44054cc50dd42597750
+  branch: rack2
+  specs:
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.0, < 3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (5.0.0.1)
+      actionpack (= 5.0.0.1)
+      nio4r (~> 1.2)
+      websocket-driver (~> 0.6.1)
+    actionmailer (5.0.0.1)
+      actionpack (= 5.0.0.1)
+      actionview (= 5.0.0.1)
+      activejob (= 5.0.0.1)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
+    actionpack (5.0.0.1)
+      actionview (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      rack (~> 2.0)
+      rack-test (~> 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.0.0.1)
+      activesupport (= 5.0.0.1)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_attr (0.9.0)
+      activemodel (>= 3.0.2, < 5.1)
+      activesupport (>= 3.0.2, < 5.1)
+    activejob (5.0.0.1)
+      activesupport (= 5.0.0.1)
+      globalid (>= 0.3.6)
+    activemodel (5.0.0.1)
+      activesupport (= 5.0.0.1)
+    activerecord (5.0.0.1)
+      activemodel (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      arel (~> 7.0)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.4.0)
+    arel (7.1.1)
+    ast (2.3.0)
+    autoprefixer-rails (6.4.0.3)
+      execjs
+    bootstrap-sass (3.3.7)
+      autoprefixer-rails (>= 5.2.1)
+      sass (>= 3.3.4)
+    bourbon (4.2.7)
+      sass (~> 3.4)
+      thor (~> 0.19)
+    builder (3.2.2)
+    byebug (9.0.5)
+    capybara (2.8.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    chronic (0.10.2)
+    coderay (1.1.1)
+    coffee-rails (4.2.1)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0, < 5.2.x)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.10.0)
+    concurrent-ruby (1.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    debug_inspector (0.0.2)
+    diff-lcs (1.2.5)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    erubis (2.7.0)
+    eventmachine (1.2.0.1)
+    execjs (2.7.0)
+    fabrication (2.15.2)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    ffi (1.9.14)
+    foreman (0.82.0)
+      thor (~> 0.19.1)
+    formatador (0.2.5)
+    globalid (0.3.7)
+      activesupport (>= 4.1.0)
+    guard (2.14.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (~> 1.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-livereload (2.5.2)
+      em-websocket (~> 0.5)
+      guard (~> 2.8)
+      guard-compat (~> 1.0)
+      multi_json (~> 1.8)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    haml (4.0.7)
+      tilt
+    haml-rails (0.9.0)
+      actionpack (>= 4.0.1)
+      activesupport (>= 4.0.1)
+      haml (>= 4.0.6, < 5.0)
+      html2haml (>= 1.0.1)
+      railties (>= 4.0.1)
+    hashdiff (0.3.0)
+    hashie (3.4.4)
+    html2haml (2.0.0)
+      erubis (~> 2.7.0)
+      haml (~> 4.0.0)
+      nokogiri (~> 1.6.0)
+      ruby_parser (~> 3.5)
+    http_parser.rb (0.6.0)
+    i18n (0.7.0)
+    jbuilder (2.6.0)
+      activesupport (>= 3.0.0, < 5.1)
+      multi_json (~> 1.2)
+    jquery-rails (4.2.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+    json (2.0.2)
+    jwt (1.5.4)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    loofah (2.0.3)
+      nokogiri (>= 1.5.9)
+    lumberjack (1.0.10)
+    mail (2.6.4)
+      mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mini_portile2 (2.1.0)
+    minitest (5.9.0)
+    multi_json (1.12.1)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
+    neat (1.8.0)
+      sass (>= 3.3)
+      thor (~> 0.19)
+    nenv (0.3.0)
+    nio4r (1.2.1)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
+    notiffany (0.1.1)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    omniauth (1.3.1)
+      hashie (>= 1.2, < 4)
+      rack (>= 1.0, < 3)
+    omniauth-oauth2 (1.4.0)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
+    parser (2.3.1.2)
+      ast (~> 2.2)
+    pkg-config (1.1.7)
+    powerpack (0.1.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    puma (3.6.0)
+    rack (2.0.1)
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rack_session_access (0.1.1)
+      builder (>= 2.0.0)
+      rack (>= 1.0.0)
+    rails (5.0.0.1)
+      actioncable (= 5.0.0.1)
+      actionmailer (= 5.0.0.1)
+      actionpack (= 5.0.0.1)
+      actionview (= 5.0.0.1)
+      activejob (= 5.0.0.1)
+      activemodel (= 5.0.0.1)
+      activerecord (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 5.0.0.1)
+      sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
+    rails-dom-testing (2.0.1)
+      activesupport (>= 4.2.0, < 6.0)
+      nokogiri (~> 1.6.0)
+    rails-html-sanitizer (1.0.3)
+      loofah (~> 2.0)
+    railties (5.0.0.1)
+      actionpack (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+    rainbow (2.1.0)
+    rake (11.2.2)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
+    responders (2.3.0)
+      railties (>= 4.2.0, < 5.1)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-rails (3.5.2)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    rubocop (0.42.0)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-enum (0.5.0)
+      i18n
+    ruby-progressbar (1.8.1)
+    ruby_parser (3.8.2)
+      sexp_processor (~> 4.1)
+    safe_yaml (1.0.4)
+    sass (3.4.22)
+    sass-rails (5.0.6)
+      railties (>= 4.0.0, < 6)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
+    sexp_processor (4.7.0)
+    shellany (0.0.1)
+    simple_form (3.3.1)
+      actionpack (> 4, < 5.1)
+      activemodel (> 4, < 5.1)
+    slop (3.6.0)
+    spring (1.7.2)
+    spring-watcher-listen (2.0.0)
+      listen (>= 2.7, < 4.0)
+      spring (~> 1.2)
+    sprockets (3.7.0)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.1.1)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
+    thor (0.19.1)
+    thread_safe (0.3.5)
+    tilt (2.0.5)
+    typhoeus (0.7.1)
+      ethon (>= 0.7.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    uglifier (3.0.2)
+      execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.1.0)
+    web-console (3.3.1)
+      actionview (>= 5.0)
+      activemodel (>= 5.0)
+      debug_inspector
+      railties (>= 5.0)
+    webmock (2.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+    websocket-driver (0.6.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  active_attr
+  bootstrap-sass
+  bourbon
+  byebug
+  capybara
+  coffee-rails (~> 4.2)
+  dotenv-rails
+  ethon!
+  fabrication
+  foreman
+  guard-livereload
+  guard-rspec
+  haml-rails
+  jbuilder (~> 2.5)
+  jquery-rails
+  kinetic!
+  listen (~> 3.0.5)
+  neat
+  oauth2!
+  omniauth-artsy!
+  omniauth-oauth2
+  puma (~> 3.0)
+  rack_session_access
+  rails (~> 5.0.0)
+  rails-controller-testing
+  rspec
+  rspec-rails
+  rubocop
+  sass-rails (~> 5.0)
+  spring
+  spring-watcher-listen (~> 2.0.0)
+  typhoeus (= 0.7.1)
+  tzinfo-data
+  uglifier (>= 1.3.0)
+  watt!
+  web-console
+  webmock
+
+RUBY VERSION
+   ruby 2.3.1p112
+
+BUNDLED WITH
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ The goal here is to optimize for ease and speed of iteration and for **<span sty
   $ bundle install
   ~~~
 
+  If the bundle step fails when trying to fetch private Artsy gems, you may need to:
+
+  0. Create a [personal access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for command line use
+  0. [Run `bundle config`](https://gist.github.com/sebboh/f1dfe4f096746c45f3e9ea06a09743a0) with your new token
+
 0. Start the server
 
   ~~~


### PR DESCRIPTION
Because Azimuth follows the template of a partner engineering app it pulls in several private Artsy gems (Kinetic, Watt, …)

Since partner apps are private their Gemfiles contain sensitive info for accessing those private repos.

This PR restores the Gemfile.lock that we removed recently, but without adding any sensitive info.